### PR TITLE
Fix test in US timezones

### DIFF
--- a/src/test/java/app/unattach/model/FilenameFactoryTest.java
+++ b/src/test/java/app/unattach/model/FilenameFactoryTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class FilenameFactoryTest {
   private static final Email email = new Email("id3", "uid42", Arrays.asList("SENT", "IMPORTANT"),
-      "\"Rok Strniša\" <rok.strnisa@gmail.com>", "subject", 1501545600000L, 32141);
+      "\"Rok Strniša\" <rok.strnisa@gmail.com>", "subject", 1501574400000L, 32141);
 
   @Test
   public void testFromEmail() {
@@ -31,7 +31,7 @@ public class FilenameFactoryTest {
 
   @Test
   public void testTimestamp() {
-    testGetFilename("${TIMESTAMP}", "a%b@.jpg", "1501545600000");
+    testGetFilename("${TIMESTAMP}", "a%b@.jpg", "1501574400000");
     testGetFilename("${TIMESTAMP:3}", "a%b@.jpg", "150");
   }
 


### PR DESCRIPTION
The timestamp used in test was right at midnight GMT and giving date 2017-07-31 instead of expected 2017-08-01 when run in US timezones. I advanced the timestamp by 8 hours to fix it.
