### PR TITLE
Support multiple configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.class
 *.log
 .DS_Store
+.factorypath
 
 # IntelliJ
 .idea/

--- a/src/main/java/app/unattach/controller/Controller.java
+++ b/src/main/java/app/unattach/controller/Controller.java
@@ -30,4 +30,6 @@ public interface Controller {
   void signOut();
   void sendToServer(String contentDescription, String exceptionText, String userText);
   void subscribe(String emailAddress);
+  void saveConfigToFile(File selectedFile);
+  void loadConfigFromFile(File selectedFile);
 }

--- a/src/main/java/app/unattach/controller/DefaultController.java
+++ b/src/main/java/app/unattach/controller/DefaultController.java
@@ -248,4 +248,27 @@ public record DefaultController(Model model) implements Controller {
       return false;
     }
   }
+
+  @Override
+  public void saveConfigToFile(File selectedFile) {
+    FileConfig fConfig = new FileConfig();
+    fConfig.saveConfigToFile(selectedFile);
+  }
+
+  @Override
+  public void loadConfigFromFile(File selectedFile) {
+    FileConfig fConfig = new FileConfig(selectedFile);
+    model.getConfig().saveDateFormat(fConfig.getDateFormat());
+    model.getConfig().saveRemoveOriginal(fConfig.getRemoveOriginal());
+    model.getConfig().saveDownloadedLabelId(fConfig.getDownloadedLabelId());
+    model.getConfig().saveEmailSize(fConfig.getEmailSize());
+    model.getConfig().saveFilenameSchema(fConfig.getFilenameSchema());
+    model.getConfig().saveLabelIds(fConfig.getLabelIds());
+    model.getConfig().saveProcessEmbedded(fConfig.getProcessEmbedded());
+    model.getConfig().saveRemovedLabelId(fConfig.getRemovedLabelId());
+    model.getConfig().saveSearchQuery(fConfig.getSearchQuery());
+    model.getConfig().saveSignInAutomatically(fConfig.getSignInAutomatically());
+    model.getConfig().saveSubscribeToUpdates(fConfig.getSubscribeToUpdates());
+    model.getConfig().saveTargetDirectory(fConfig.getTargetDirectory());
+  }
 }

--- a/src/main/java/app/unattach/controller/DefaultController.java
+++ b/src/main/java/app/unattach/controller/DefaultController.java
@@ -113,7 +113,7 @@ public record DefaultController(Model model) implements Controller {
 
   @Override
   public void openQueryLanguagePage() {
-    openWebPage("https://support.google.com/mail/answer/7190");
+    openWebPage(Constants.QUERY_LANGUAGE_URL);
   }
 
   @Override

--- a/src/main/java/app/unattach/model/Constants.java
+++ b/src/main/java/app/unattach/model/Constants.java
@@ -16,4 +16,5 @@ public final class Constants {
   public static final String PRODUCT_NAME = "Unattach";
   public static final String VERSION = "3.3.0";
   public static final boolean DEBUG_MODE = false;
+  public static final String QUERY_LANGUAGE_URL = "https://support.google.com/mail/answer/7190";
 }

--- a/src/main/java/app/unattach/model/FileConfig.java
+++ b/src/main/java/app/unattach/model/FileConfig.java
@@ -9,27 +9,40 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
-import java.util.Set;
 
 public class FileConfig extends BaseConfig {
   private static final Logger logger = Logger.get();
 
+  public FileConfig() {
+    loadConfig();
+  }
+
+  public FileConfig(File configFile) {
+    loadConfigFromFile(configFile);
+  }
+
   @Override
   public void loadConfig() {
-    File configFile = getConfigPath().toFile();
+    loadConfigFromFile(getConfigPath().toFile());
+  }  
+
+  public void loadConfigFromFile(File configFile) {
     if (configFile.exists()) {
       try (FileInputStream in = new FileInputStream(configFile)) {
         config.load(in);
       } catch (IOException e) {
         logger.error("Failed to load the config file.", e);
-      }
-    }
-  }
+      }  
+    }  
+  }  
 
   @Override
   public void saveConfig() {
+    saveConfigToFile(getConfigPath().toFile());
+  }
+
+  public void saveConfigToFile(File configFile) {
     removeUnknownProperties();
-    File configFile = getConfigPath().toFile();
     try (FileOutputStream out = new FileOutputStream(configFile)) {
       config.store(out, null);
     } catch (IOException e) {

--- a/src/main/java/app/unattach/model/FileConfig.java
+++ b/src/main/java/app/unattach/model/FileConfig.java
@@ -32,9 +32,9 @@ public class FileConfig extends BaseConfig {
         config.load(in);
       } catch (IOException e) {
         logger.error("Failed to load the config file.", e);
-      }  
-    }  
-  }  
+      }
+    }
+  }
 
   @Override
   public void saveConfig() {

--- a/src/main/java/app/unattach/view/MainViewController.java
+++ b/src/main/java/app/unattach/view/MainViewController.java
@@ -20,6 +20,8 @@ import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.layout.VBox;
 import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.Duration;
@@ -29,6 +31,7 @@ import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -750,6 +753,47 @@ public class MainViewController {
       Scenes.showAndPreventMakingSmaller(dialog);
     } catch (IOException e) {
       logger.error("Failed to open the Unattach labels dialog.", e);
+    }
+  }
+
+  @FXML
+  private void onLoadConfigPressed() {
+    FileChooser fileChooser = new FileChooser();
+    fileChooser.setTitle("Open Settings File");
+    String userHome = System.getProperty("user.home");
+    fileChooser.setInitialDirectory(new File(Paths.get(userHome).toString()));
+    fileChooser.getExtensionFilters().addAll(
+            new ExtensionFilter("Unattach Settings", "*.unattach"),
+            new ExtensionFilter("All Files", "*.*"));
+    File selectedFile = fileChooser.showOpenDialog(root.getScene().getWindow());
+    if (selectedFile != null) {
+      controller.loadConfigFromFile(selectedFile);
+      targetDirectoryTextField.setText(controller.getConfig().getTargetDirectory());
+      searchQueryTextField.setText(controller.getConfig().getSearchQuery());
+      processEmbeddedCheckMenuItem.setSelected(controller.getConfig().getProcessEmbedded());
+      permanentlyRemoveOriginalMenuItem.setSelected(controller.getConfig().getRemoveOriginal());
+      trashOriginalMenuItem.setSelected(!controller.getConfig().getRemoveOriginal());
+      signInAutomaticallyCheckMenuItem.setSelected(controller.getConfig().getSignInAutomatically());
+
+      String pattern = controller.getConfig().getDateFormat();
+      for( MenuItem menuItem : dateFormatMenu.getItems()) {
+        ((CheckMenuItem) menuItem).setSelected(menuItem.getText().equals(pattern));
+      };
+    }
+  }
+
+  @FXML
+  private void onSaveConfigPressed() {
+    FileChooser fileChooser = new FileChooser();
+    fileChooser.setTitle("Save Settings to File");
+    String userHome = System.getProperty("user.home");
+    fileChooser.setInitialDirectory(new File(Paths.get(userHome).toString()));
+    fileChooser.getExtensionFilters().addAll(
+            new ExtensionFilter("Unattach Settings", "*.unattach"),
+            new ExtensionFilter("All Files", "*.*"));
+    File selectedFile = fileChooser.showSaveDialog(root.getScene().getWindow());
+    if (selectedFile != null) {
+      controller.saveConfigToFile(selectedFile);
     }
   }
 

--- a/src/main/java/app/unattach/view/SelectedCheckBoxTableCellFactory.java
+++ b/src/main/java/app/unattach/view/SelectedCheckBoxTableCellFactory.java
@@ -10,7 +10,6 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
 import javafx.util.Callback;
-import org.apache.commons.lang3.StringUtils;
 
 public class SelectedCheckBoxTableCellFactory
     implements Callback<TableColumn.CellDataFeatures<Email, CheckBox>, ObservableValue<CheckBox>> {

--- a/src/main/resources/main.view.fxml
+++ b/src/main/resources/main.view.fxml
@@ -34,6 +34,9 @@
       <MenuItem text="File name schema..." onAction="#onFilenameSchemaMenuItemPressed" />
       <MenuItem text="Unattach labels..." onAction="#onUnattachLabelMenuItemPressed" />
       <Menu fx:id="donationCurrencyMenu" text="Donation currency" />
+      <SeparatorMenuItem/>
+      <MenuItem text="Load Configuration..." onAction="#onLoadConfigPressed" />
+      <MenuItem text="Save Configuration..." onAction="#onSaveConfigPressed" />
     </Menu>
     <Menu text="Help">
       <MenuItem text="Tutorial Video" onAction="#onTutorialVideoButtonPressed"/>


### PR DESCRIPTION
Let the user save the current configuration into a file of his choice and reload it when he wants to.
For this in the Settings menu now two more entries exist: Load Configuration and Save Configuration.
An example use case for this is if the user wants to store the attachments of sent mails in another folder than the attachments of received mails.
