### PR TITLE
Improve filename handling

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,4 +2,4 @@
 
 set -e -u -x -o pipefail
 
-mvn test
+mvn clean test

--- a/src/main/java/app/unattach/utils/FilenameDecoder.java
+++ b/src/main/java/app/unattach/utils/FilenameDecoder.java
@@ -1,0 +1,43 @@
+package app.unattach.utils;
+
+import javax.mail.MessagingException;
+import javax.mail.Part;
+import javax.mail.internet.MimeUtility;
+import java.io.UnsupportedEncodingException;
+
+public class FilenameDecoder {
+  private static final Logger logger = Logger.get();
+
+  public static String getFilename(Part part) throws MessagingException {
+    String rawFilename = part.getFileName();
+    if (rawFilename == null) {
+      return null;
+    }
+    return decode(rawFilename);
+  }
+
+  public static String decode(String encodedFilename) {
+    try {
+      return decodeAndPostprocess(encodedFilename);
+    } catch (UnsupportedEncodingException e) {
+      logger.warn("Unable to decode a filename: " + encodedFilename, e);
+      if (encodedFilename.startsWith("=?iso-8859-8-1?")) {
+        logger.warn("Detected iso-8859-8-1 encoding. Attempting a workaround...");
+        String input = encodedFilename.replaceAll("=\\?iso-8859-8-1\\?", "=?iso-8859-8?");
+        try {
+          return decodeAndPostprocess(input);
+        } catch (UnsupportedEncodingException ex) {
+          logger.error("Workaround failed: " + encodedFilename, ex);
+          return null;
+        }
+      }
+      return null;
+    }
+  }
+
+  private static String decodeAndPostprocess(String encoded) throws UnsupportedEncodingException {
+    // Attempt to parse invalid encodings.
+    System.setProperty("mail.mime.decodetext.strict", "false");
+    return MimeUtility.decodeText(encoded).trim();
+  }
+}

--- a/src/test/java/app/unattach/utils/AttachmentNameExtractorTest.java
+++ b/src/test/java/app/unattach/utils/AttachmentNameExtractorTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class AttachmentNameExtractorTest {
+public class AttachmentNameExtractorTest {
   @Test
   void test_getAttachmentNames_SHOULD_extract_all_names_WHEN_there_are_sub_parts() throws IOException {
     JsonFactory factory = GsonFactory.getDefaultInstance();

--- a/src/test/java/app/unattach/utils/FilenameDecoderTest.java
+++ b/src/test/java/app/unattach/utils/FilenameDecoderTest.java
@@ -7,7 +7,7 @@ import java.io.UnsupportedEncodingException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class FilenameDecoderTest {
+public class FilenameDecoderTest {
   @Test
   void decode_SHOULD_the_same_WHEN_no_special_characters() {
     String encodedFilename = "test";

--- a/src/test/java/app/unattach/utils/FilenameDecoderTest.java
+++ b/src/test/java/app/unattach/utils/FilenameDecoderTest.java
@@ -1,0 +1,59 @@
+package app.unattach.utils;
+
+import org.junit.jupiter.api.Test;
+
+import javax.mail.internet.MimeUtility;
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilenameDecoderTest {
+  @Test
+  void decode_SHOULD_the_same_WHEN_no_special_characters() {
+    String encodedFilename = "test";
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals(encodedFilename, decodedFilename);
+  }
+
+  @Test
+  void decode_SHOULD_trim_whitespace_WHEN_filename_starts_or_ends_with_whitespace() {
+    String encodedFilename = "  test  ";
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals(encodedFilename.trim(), decodedFilename);
+  }
+
+  @Test
+  void decode_SHOULD_the_same_WHEN_the_filename_is_similar_to_encoding() {
+    String encodedFilename = "=?iso-8859-8?";
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals(encodedFilename, decodedFilename);
+  }
+
+  @Test
+  void decode_SHOULD_handle_hebrew_WHEN_no_diacritical_marks() throws UnsupportedEncodingException {
+    String filename = "עברית";
+    String encodedFilename = MimeUtility.encodeText(filename, "iso-8859-8", null);
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals(filename, decodedFilename);
+  }
+
+  @Test
+  void decode_SHOULD_somewhat_handle_hebrew_WHEN_diacritical_marks() throws UnsupportedEncodingException {
+    String filename = "עִברִית";
+    String encodedFilename = MimeUtility.encodeText(filename, "iso-8859-8", null);
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals("ע?בר?ית", decodedFilename);
+  }
+
+  @Test
+  void decode_SHOULD_handle_hebrew_WHEN_alternative_encoding() throws UnsupportedEncodingException {
+    String fakePrefix = "=?iso-8859-8-1?";
+    String filename = fakePrefix + "עברית";
+    String encodedFilename = MimeUtility.encodeText(filename, "iso-8859-8", null);
+    System.out.println(encodedFilename);
+    encodedFilename = encodedFilename.replaceAll("=\\?iso-8859-8\\?", "=?iso-8859-8-1?");
+    System.out.println(encodedFilename);
+    String decodedFilename = FilenameDecoder.decode(encodedFilename);
+    assertEquals(filename, decodedFilename);
+  }
+}


### PR DESCRIPTION
When processing an email, `EmailProcessor` would keep a record of the original filename to new filename mapping in `originalToNormalizedFilename`. However, even the original filename is potentially encoded and the map contains the decoded version of the original filename, while `generateTextSuffix` and `generateHtmlSuffix` were looking for the encoded version and so in rare cases resulting in #52.

This PR also improves the decoding of the filename and adds some tests for it.